### PR TITLE
easeInBounce & easeInElastic mouse movements deleted because of weird behavior

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ def windowMP() :
 
 # define function to use mouse on Windows & Linux
 def mouse_random_movement():
-    return random.choices([pyautogui.easeInQuad, pyautogui.easeOutQuad, pyautogui.easeInOutQuad, pyautogui.easeInBounce, pyautogui.easeInElastic])[0]
+    return random.choices([pyautogui.easeInQuad, pyautogui.easeOutQuad, pyautogui.easeInOutQuad])[0]
 
 def configread():
     global Resolution


### PR DESCRIPTION
Sometime the bot don't do the right thing because of this 2 movements
Example : when it try to create Botwork group, the heroe card is not drop in the correct zone